### PR TITLE
Fix the parser for the downloaded file

### DIFF
--- a/lib/gallery_saver.dart
+++ b/lib/gallery_saver.dart
@@ -71,6 +71,9 @@ class GallerySaver {
     var fileUri = Uri.parse(url);
     var req = await _client.get(fileUri);
     var fileName = fileUri.pathSegments.last;
+    while (Uri.parse(fileName).pathSegments.length > 1) {
+      fileName = Uri.parse(fileName).pathSegments.last;
+    }
     var bytes = req.bodyBytes;
     String dir = (await getTemporaryDirectory()).path;
     File file = new File('$dir/$fileName');


### PR DESCRIPTION
When a video is downloaded from Firebase Storage, it's filename has "/" encoded as "%2F", and as a result, we need to use Uri.parse two times, to get the actual file name instead of the full Cloud Storage path.